### PR TITLE
Update ALLOWED_HOSTS to be blank for set-up steps

### DIFF
--- a/01_getting_set_up/01_create_project_app/codestar/settings.py
+++ b/01_getting_set_up/01_create_project_app/codestar/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-&m%gu-ez==#b@$+_t99xi_wgv()$4vr7#$-og^=x4rdhx6lh6j
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["8000-ajgreaves-blog-lesson-pl-lfv6kgfdws.us2.codeanyapp.com"]
+ALLOWED_HOSTS = []
 
 
 # Application definition


### PR DESCRIPTION
Not all students will need 'localhost' on VS Code. I needed '127.0.0.0' instead. I'm leaving ALLOWED_HOSTS empty until deployment steps when they can copy the correct deployment host from the error message like they did on cloud IDEs